### PR TITLE
remove .s/.S but add .dasm

### DIFF
--- a/DCPU-16.tmLanguage
+++ b/DCPU-16.tmLanguage
@@ -4,8 +4,7 @@
 <dict>
 	<key>fileTypes</key>
 	<array>
-		<string>s</string>
-		<string>S</string>
+		<string>dasm</string>
 		<string>dasm16</string>
 	</array>
 	<key>name</key>


### PR DESCRIPTION
.dasm is really common, but .s is used by gcc.
